### PR TITLE
fix(leaderboard): prevent x and y scroll on leaderboard header #134

### DIFF
--- a/src/components/leaderboard.svelte
+++ b/src/components/leaderboard.svelte
@@ -38,6 +38,7 @@
     border-bottom-right-radius: 10%;
     position: relative; /* add this line to create a new stacking context */
     z-index: 1;
+    overflow: hidden;
   }
   .leaderboard-detail {
     height: 44%;


### PR DESCRIPTION
Closes #134 

Also fixes overflow y scroll on leaderboard header